### PR TITLE
Image ver

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you have not done so already, then please [install Docker](https://www.docker
 Declare the plugin (typically in a `plugins.sbt`):
 
 ```scala
-addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.0.2")
+addSbtPlugin("com.typesafe.conductr" % "sbt-conductr-sandbox" % "1.0.3")
 ```
 
 Then enable the `ConductRSandbox` plugin for your module. For example:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ sandbox stop
 
 ## Features
 
+> In order to use the following features then you should ensure that the machine that runs Docker has enough memory, typically at least 2GB. VM configurations such as those provided via `boot2docker` and Oracle's VirtualBox can be configured like so:
+> ```
+> boot2docker down
+> VBoxManage modifyvm boot2docker-vm --memory 2048
+> boot2docker up
+> ```
+
 ConductR provides additional features which can be optionally enabled:
 
 Name          | CondutR port | Docker port | Description

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ sbt-conductr-sandbox aims to support the running of a Docker-based ConductR clus
 
 ## Usage
 
+The single node version of the ConductR Developer Sandbox is available gratis with registration at Typesafe.com. Please visit the [ConductR Developer](http://www.typesafe.com/product/conductr/developer) page on Typesafe.com for the current image version and licensing information. Use of the ConductR in multi-node mode or for production purposes requires the purchase of Typesafe ConductR. You <strong>must</strong> specify the current imageVersion which you can obtain from the [ConductR Developer](http://www.typesafe.com/product/conductr/developer) page.
+
 If you have not done so already, then please [install Docker](https://www.docker.com/).
 
 Declare the plugin (typically in a `plugins.sbt`):
@@ -152,6 +154,7 @@ Name              | Scope   | Description
 ------------------|---------|------------
 envs              | Global  | A `Map[String, String]` of environment variables to be set for each ConductR container.
 image             | Global  | The Docker image to use. By default `typesafe-docker-internal-docker.bintray.io/conductr/conductr-dev` is used i.e. the single node version of ConductR. For the full version please [download it via our website](http://www.typesafe.com/products/conductr) and then use just `typesafe-docker-internal-docker.bintray.io/conductr/conductr`.
+imageVersion      | Global  | The version of the Docker image to use. Must be set. Please visit the [ConductR Developer](http://www.typesafe.com/product/conductr/developer) page on Typesafe.com for the current version and additional information.
 ports             | Global  | A `Seq[Int]` of ports to be made public by each of the ConductR containers. This will be complemented to the `endpoints` setting's service ports declared for `sbt-bundle`.
 debugPort         | Project | Debug port to be made public to the ConductR containers if the sandbox gets started in [debug mode](#Commands). The debug ports of each sbt project setting will be used. If `sbt-bundle` is enabled the JVM argument `-jvm-debug $debugPort` is  additionally added to the `startCommand` of `sbt-bundle`. Default is 5005.
 logLevel          | Global  | The log level of ConductR which can be one of "debug", "warning" or "info". By default this is set to "info". You can observe ConductR's logging via the `docker logs` command. For example `docker logs -f cond-0` will follow the logs of the first ConductR container.

--- a/sbt-conductr-sandbox-tester/build.sbt
+++ b/sbt-conductr-sandbox-tester/build.sbt
@@ -14,6 +14,5 @@ BundleKeys.startCommand := Seq("-Xms1G")
 
 BundleKeys.configurationName := "frontend"
 
-SandboxKeys.image in Global := "typesafe-docker-internal-docker.bintray.io/conductr/conductr-dev"
 SandboxKeys.ports in Global := Set(9999)
 SandboxKeys.debugPort := 5432

--- a/sbt-conductr-sandbox-tester/build.sbt
+++ b/sbt-conductr-sandbox-tester/build.sbt
@@ -15,4 +15,6 @@ BundleKeys.startCommand := Seq("-Xms1G")
 BundleKeys.configurationName := "frontend"
 
 SandboxKeys.ports in Global := Set(9999)
+SandboxKeys.imageVersion in Global := "0.3.0"
+
 SandboxKeys.debugPort := 5432

--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
@@ -84,7 +84,7 @@ object ConductRSandbox extends AutoPlugin {
     }
   }
 
-  private final val ConductRDevImage = "typesafe-docker-internal-docker.bintray.io/conductr/conductr-dev"
+  private final val ConductRDevImage = "typesafe-docker-internal-docker.bintray.io/conductr/conductr-dev:0.2.0"
 
   private final val ConductrNamePrefix = "cond-"
 

--- a/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
+++ b/src/main/scala/com/typesafe/conductr/sandbox/sbt/ConductRSandbox.scala
@@ -88,7 +88,7 @@ object ConductRSandbox extends AutoPlugin {
     }
   }
 
-  private final val ConductRDevImage = "typesafe-docker-internal-docker.bintray.io/conductr/conductr-dev:0.2.0"
+  private final val ConductRDevImage = "typesafe-docker-internal-docker.bintray.io/conductr/conductr-dev"
 
   private final val ConductrNamePrefix = "cond-"
 

--- a/src/sbt-test/sbt-conductr-sandbox/basic/test
+++ b/src/sbt-test/sbt-conductr-sandbox/basic/test
@@ -1,3 +1,7 @@
+-> sandbox run
+
+> 'set SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")'
+
 > sandbox run
 
 > checkConductRIsRunning

--- a/src/sbt-test/sbt-conductr-sandbox/basic/test
+++ b/src/sbt-test/sbt-conductr-sandbox/basic/test
@@ -1,6 +1,6 @@
 -> sandbox run
 
-> 'set SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")'
+> 'set SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.3.0")'
 
 > sandbox run
 

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
@@ -16,6 +16,7 @@ BundleKeys.endpoints := Map("other" -> Endpoint("http", services = Set(URI("http
 // ConductR sandbox keys
 SandboxKeys.ports in Global := Set(1111, 2222)
 SandboxKeys.debugPort := 5432
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")
 
 /**
  * Check ports after 'sandbox run' command

--- a/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-basic/build.sbt
@@ -16,7 +16,7 @@ BundleKeys.endpoints := Map("other" -> Endpoint("http", services = Set(URI("http
 // ConductR sandbox keys
 SandboxKeys.ports in Global := Set(1111, 2222)
 SandboxKeys.debugPort := 5432
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.3.0")
 
 /**
  * Check ports after 'sandbox run' command

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
@@ -6,7 +6,6 @@ version := "0.1.0-SNAPSHOT"
 
 // ConductR global keys
 SandboxKeys.ports in Global := Set(1111, 2222)
-SandboxKeys.image in Global := "typesafe-docker-internal-docker.bintray.io/conductr/conductr-dev"
 
 lazy val common = (project in file("modules/common"))
   .enablePlugins(ConductRSandbox)

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
@@ -6,6 +6,7 @@ version := "0.1.0-SNAPSHOT"
 
 // ConductR global keys
 SandboxKeys.ports in Global := Set(1111, 2222)
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")
 
 lazy val common = (project in file("modules/common"))
   .enablePlugins(ConductRSandbox)

--- a/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/ports-multi-module/build.sbt
@@ -6,7 +6,7 @@ version := "0.1.0-SNAPSHOT"
 
 // ConductR global keys
 SandboxKeys.ports in Global := Set(1111, 2222)
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.3.0")
 
 lazy val common = (project in file("modules/common"))
   .enablePlugins(ConductRSandbox)

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
@@ -12,6 +12,8 @@ BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")
+
 /**
  * Check ports after 'sandbox run' command
  */

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
@@ -1,8 +1,6 @@
 import org.scalatest.Matchers._
 import ByteConversions._
 
-import scala.util.Try
-
 lazy val root = (project in file(".")).enablePlugins(ConductRSandbox)
 
 name := "with-features"
@@ -33,24 +31,4 @@ checkEnvs := {
   val content = "docker inspect --format='{{.Config.Env}}' cond-0".!!
   val expectedContent = "CONDUCTR_FEATURES=visualization,logging"
   content should include(expectedContent)
-}
-
-val waitForBundles = taskKey[Unit]("Wait that bundles has been started.")
-waitForBundles := {
-  Thread.sleep(30000)
-}
-
-val checkConnection = taskKey[Unit]("Check if the features are reachable.")
-checkConnection := {
-  val dockerIp =
-    Try("boot2docker ip".!!.trim.reverse.takeWhile(_ != ' ').reverse).getOrElse("hostname".!!.trim)
-
-  def curl(port: Int): String =
-    (s"curl -IL http://$dockerIp:$port 2>/dev/null" #| "head -n 1").!!
-
-  val visualization_status_code = curl(9909)
-  visualization_status_code should include("200")
-
-  val logging_status_code = curl(9200)
-  logging_status_code should include("503")
 }

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/build.sbt
@@ -12,7 +12,7 @@ BundleKeys.nrOfCpus := 1.0
 BundleKeys.memory := 64.MiB
 BundleKeys.diskSpace := 10.MB
 
-SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.1.0")
+SandboxKeys.imageVersion in Global := sys.props.getOrElse("IMAGE_VERSION", default = "0.3.0")
 
 /**
  * Check ports after 'sandbox run' command

--- a/src/sbt-test/sbt-conductr-sandbox/with-features/test
+++ b/src/sbt-test/sbt-conductr-sandbox/with-features/test
@@ -4,8 +4,4 @@
 
 > checkEnvs
 
-> waitForBundles
-
-> checkConnection
-
 > sandbox stop

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.3"
+version in ThisBuild := "1.1.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.0-SNAPSHOT"
+version in ThisBuild := "1.0.3"


### PR DESCRIPTION
You will first need to rebase your `imageVer` branch with the typesafehub/sbt-conductr-sandbox master branch to be able to merge this PR.
